### PR TITLE
Fix kernel crash if Lustre is builtin and fix build error on powerpc

### DIFF
--- a/drivers/staging/lustre/Makefile
+++ b/drivers/staging/lustre/Makefile
@@ -1,4 +1,4 @@
 subdir-ccflags-y := -I$(src)/include/
 
-obj-$(CONFIG_LUSTRE_FS)		+= lustre/
 obj-$(CONFIG_LNET)		+= lnet/
+obj-$(CONFIG_LUSTRE_FS)		+= lustre/

--- a/drivers/staging/lustre/include/linux/libcfs/linux/linux-prim.h
+++ b/drivers/staging/lustre/include/linux/libcfs/linux/linux-prim.h
@@ -150,8 +150,8 @@ typedef struct task_struct	      task_t;
 	} while(0)
 
 /* Module interfaces */
-#define cfs_module(name, version, init, fini) \
-	module_init(init);		    \
+#define cfs_module(name, version, init, fini)	\
+	late_initcall(init);			\
 	module_exit(fini)
 
 /*

--- a/drivers/staging/lustre/include/linux/libcfs/linux/linux-tcpip.h
+++ b/drivers/staging/lustre/include/linux/libcfs/linux/linux-tcpip.h
@@ -48,8 +48,12 @@
 
 #include <net/sock.h>
 
-#ifndef HIPQUAD
-// XXX Should just kill all users
+#define NIPQUAD(addr) \
+        ((unsigned char *)&addr)[0], \
+        ((unsigned char *)&addr)[1], \
+        ((unsigned char *)&addr)[2], \
+        ((unsigned char *)&addr)[3]
+
 #if defined(__LITTLE_ENDIAN)
 #define HIPQUAD(addr) \
 	((unsigned char *)&addr)[3], \
@@ -61,7 +65,6 @@
 #else
 #error "Please fix asm/byteorder.h"
 #endif /* __LITTLE_ENDIAN */
-#endif
 
 typedef struct socket   socket_t;
 

--- a/drivers/staging/lustre/lnet/Makefile
+++ b/drivers/staging/lustre/lnet/Makefile
@@ -1,1 +1,3 @@
-obj-$(CONFIG_LNET) := klnds/ lnet/ selftest/
+obj-$(CONFIG_LNET) += lnet/
+obj-$(CONFIG_LNET) += klnds/
+obj-$(CONFIG_LNET) += selftest/

--- a/drivers/staging/lustre/lnet/klnds/o2iblnd/o2iblnd.c
+++ b/drivers/staging/lustre/lnet/klnds/o2iblnd/o2iblnd.c
@@ -3255,5 +3255,5 @@ MODULE_AUTHOR("Sun Microsystems, Inc. <http://www.lustre.org/>");
 MODULE_DESCRIPTION("Kernel OpenIB gen2 LND v2.00");
 MODULE_LICENSE("GPL");
 
-module_init(kiblnd_module_init);
+late_initcall(kiblnd_module_init);
 module_exit(kiblnd_module_fini);

--- a/drivers/staging/lustre/lnet/lnet/api-ni.c
+++ b/drivers/staging/lustre/lnet/lnet/api-ni.c
@@ -1541,7 +1541,10 @@ LNetGetId(unsigned int index, lnet_process_id_t *id)
 	int		rc = -ENOENT;
 
 	LASSERT(the_lnet.ln_init);
-	LASSERT(the_lnet.ln_refcount > 0);
+
+	/* LNetNI initilization failed? */
+	if (the_lnet.ln_refcount == 0)
+		return rc;
 
 	cpt = lnet_net_lock_current();
 

--- a/drivers/staging/lustre/lustre/Makefile
+++ b/drivers/staging/lustre/lustre/Makefile
@@ -1,2 +1,9 @@
-obj-$(CONFIG_LUSTRE_FS) := fid/ lvfs/ obdclass/ ptlrpc/ obdecho/ mgc/ lov/ \
-			   osc/ mdc/ lmv/ llite/ fld/ libcfs/
+obj-$(CONFIG_LUSTRE_FS) += libcfs/
+obj-$(CONFIG_LUSTRE_FS) += lvfs/
+obj-$(CONFIG_LUSTRE_FS) += obdclass/
+obj-$(CONFIG_LUSTRE_FS) += ptlrpc/
+obj-$(CONFIG_LUSTRE_FS) += fld/ osc/ mgc/
+obj-$(CONFIG_LUSTRE_FS) += fid/ lov/
+obj-$(CONFIG_LUSTRE_FS) += mdc/ lmv/
+obj-$(CONFIG_LUSTRE_FS) += llite/
+obj-$(CONFIG_LUSTRE_FS) += obdecho/

--- a/drivers/staging/lustre/lustre/include/linux/lustre_compat25.h
+++ b/drivers/staging/lustre/lustre/include/linux/lustre_compat25.h
@@ -74,17 +74,6 @@ static inline void ll_set_fs_pwd(struct fs_struct *fs, struct vfsmount *mnt,
 #define current_ngroups current_cred()->group_info->ngroups
 #define current_groups current_cred()->group_info->small_block
 
-/*
- * OBD need working random driver, thus all our
- * initialization routines must be called after device
- * driver initialization
- */
-#ifndef MODULE
-#undef module_init
-#define module_init(a)     late_initcall(a)
-#endif
-
-
 #define LTIME_S(time)		   (time.tv_sec)
 
 #define ll_permission(inode,mask,nd)    inode_permission(inode,mask)

--- a/drivers/staging/lustre/lustre/libcfs/module.c
+++ b/drivers/staging/lustre/lustre/libcfs/module.c
@@ -495,4 +495,5 @@ static void exit_libcfs_module(void)
 	libcfs_arch_cleanup();
 }
 
-cfs_module(libcfs, "1.0.0", init_libcfs_module, exit_libcfs_module);
+module_init(init_libcfs_module);
+module_exit(exit_libcfs_module);

--- a/drivers/staging/lustre/lustre/llite/lloop.c
+++ b/drivers/staging/lustre/lustre/llite/lloop.c
@@ -858,7 +858,7 @@ static void lloop_exit(void)
 	OBD_FREE(loop_dev, max_loop * sizeof(*loop_dev));
 }
 
-module_init(lloop_init);
+late_initcall(lloop_init);
 module_exit(lloop_exit);
 
 CFS_MODULE_PARM(max_loop, "i", int, 0444, "maximum of lloop_device");

--- a/drivers/staging/lustre/lustre/llite/super25.c
+++ b/drivers/staging/lustre/lustre/llite/super25.c
@@ -222,5 +222,5 @@ MODULE_AUTHOR("Sun Microsystems, Inc. <http://www.lustre.org/>");
 MODULE_DESCRIPTION("Lustre Lite Client File System");
 MODULE_LICENSE("GPL");
 
-module_init(init_lustre_lite);
+late_initcall(init_lustre_lite);
 module_exit(exit_lustre_lite);

--- a/drivers/staging/lustre/lustre/lmv/lmv_obd.c
+++ b/drivers/staging/lustre/lustre/lmv/lmv_obd.c
@@ -2723,5 +2723,5 @@ MODULE_AUTHOR("Sun Microsystems, Inc. <http://www.lustre.org/>");
 MODULE_DESCRIPTION("Lustre Logical Metadata Volume OBD driver");
 MODULE_LICENSE("GPL");
 
-module_init(lmv_init);
+late_initcall(lmv_init);
 module_exit(lmv_exit);

--- a/drivers/staging/lustre/lustre/lvfs/fsfilt_ext3.c
+++ b/drivers/staging/lustre/lustre/lvfs/fsfilt_ext3.c
@@ -753,7 +753,7 @@ static void __exit fsfilt_ext3_exit(void)
 	LASSERTF(rc == 0, "couldn't destroy fcb_cache slab\n");
 }
 
-module_init(fsfilt_ext3_init);
+late_initcall(fsfilt_ext3_init);
 module_exit(fsfilt_ext3_exit);
 
 MODULE_AUTHOR("Sun Microsystems, Inc. <http://www.lustre.org/>");

--- a/drivers/staging/lustre/lustre/mdc/mdc_request.c
+++ b/drivers/staging/lustre/lustre/mdc/mdc_request.c
@@ -2749,5 +2749,5 @@ MODULE_AUTHOR("Sun Microsystems, Inc. <http://www.lustre.org/>");
 MODULE_DESCRIPTION("Lustre Metadata Client");
 MODULE_LICENSE("GPL");
 
-module_init(mdc_init);
+late_initcall(mdc_init);
 module_exit(mdc_exit);

--- a/drivers/staging/lustre/lustre/mgc/mgc_request.c
+++ b/drivers/staging/lustre/lustre/mgc/mgc_request.c
@@ -1856,5 +1856,5 @@ MODULE_AUTHOR("Sun Microsystems, Inc. <http://www.lustre.org/>");
 MODULE_DESCRIPTION("Lustre Management Client");
 MODULE_LICENSE("GPL");
 
-module_init(mgc_init);
+late_initcall(mgc_init);
 module_exit(mgc_exit);

--- a/drivers/staging/lustre/lustre/obdclass/llog_test.c
+++ b/drivers/staging/lustre/lustre/obdclass/llog_test.c
@@ -1083,5 +1083,5 @@ MODULE_AUTHOR("Sun Microsystems, Inc. <http://www.lustre.org/>");
 MODULE_DESCRIPTION("llog test module");
 MODULE_LICENSE("GPL");
 
-module_init(llog_test_init);
+late_initcall(llog_test_init);
 module_exit(llog_test_exit);

--- a/drivers/staging/lustre/lustre/obdclass/lu_object.c
+++ b/drivers/staging/lustre/lustre/obdclass/lu_object.c
@@ -1315,7 +1315,7 @@ int lu_context_key_register(struct lu_context_key *key)
 	LASSERT(key->lct_init != NULL);
 	LASSERT(key->lct_fini != NULL);
 	LASSERT(key->lct_tags != 0);
-	LASSERT(key->lct_owner != NULL);
+	LASSERT(key->lct_owner != NULL || IS_BUILTIN(CONFIG_LUSTRE_FS));
 
 	result = -ENFILE;
 	spin_lock(&lu_keys_guard);
@@ -1349,7 +1349,7 @@ static void key_fini(struct lu_context *ctx, int index)
 		lu_ref_del(&key->lct_reference, "ctx", ctx);
 		atomic_dec(&key->lct_used);
 
-		LASSERT(key->lct_owner != NULL);
+		LASSERT(key->lct_owner != NULL || IS_BUILTIN(CONFIG_LUSTRE_FS));
 		if ((ctx->lc_tags & LCT_NOREF) == 0) {
 #ifdef CONFIG_MODULE_UNLOAD
 			LINVRNT(module_refcount(key->lct_owner) > 0);
@@ -1557,7 +1557,8 @@ static int keys_fill(struct lu_context *ctx)
 			if (unlikely(IS_ERR(value)))
 				return PTR_ERR(value);
 
-			LASSERT(key->lct_owner != NULL);
+			LASSERT(key->lct_owner != NULL ||
+				IS_BUILTIN(CONFIG_LUSTRE_FS));
 			if (!(ctx->lc_tags & LCT_NOREF))
 				try_module_get(key->lct_owner);
 			lu_ref_add_atomic(&key->lct_reference, "ctx", ctx);

--- a/drivers/staging/lustre/lustre/ptlrpc/gss/sec_gss.c
+++ b/drivers/staging/lustre/lustre/ptlrpc/gss/sec_gss.c
@@ -2912,5 +2912,5 @@ MODULE_AUTHOR("Sun Microsystems, Inc. <http://www.lustre.org/>");
 MODULE_DESCRIPTION("GSS security policy for Lustre");
 MODULE_LICENSE("GPL");
 
-module_init(sptlrpc_gss_init);
+late_initcall(sptlrpc_gss_init);
 module_exit(sptlrpc_gss_exit);


### PR DESCRIPTION
With bellow fixes, we still cannot mount if Lustre is builtin, but we don't crash kernel now.

Peng Tao (5):
      staging/lustre: fix Lustre code link order
      staging/lustre: fix Lustre init functions level
      staging/lustre: don't assert module owner if Lustre is builtin
      staging/lustre: don't assert ln_refcount in LNetGetId
      staging/lustre: fix build error on BIGENDIAN machines
